### PR TITLE
Use pointer cursor for delete order button.

### DIFF
--- a/save-points/00-Starting-point/BlazingPizza.Client/wwwroot/css/site.css
+++ b/save-points/00-Starting-point/BlazingPizza.Client/wwwroot/css/site.css
@@ -298,6 +298,7 @@ form {
     top: 0;
     right: 0;
     content: 'X';
+    cursor: pointer;
     color: #fff2cc;
     width: 2rem;
     height: 2rem;

--- a/save-points/01-Components-and-layout/BlazingPizza.Client/wwwroot/css/site.css
+++ b/save-points/01-Components-and-layout/BlazingPizza.Client/wwwroot/css/site.css
@@ -298,6 +298,7 @@ form {
     top: 0;
     right: 0;
     content: 'X';
+    cursor: pointer;
     color: #fff2cc;
     width: 2rem;
     height: 2rem;

--- a/save-points/02-customize-a-pizza/BlazingPizza.Client/wwwroot/css/site.css
+++ b/save-points/02-customize-a-pizza/BlazingPizza.Client/wwwroot/css/site.css
@@ -298,6 +298,7 @@ form {
     top: 0;
     right: 0;
     content: 'X';
+    cursor: pointer;
     color: #fff2cc;
     width: 2rem;
     height: 2rem;

--- a/save-points/03-show-order-status/BlazingPizza.Client/wwwroot/css/site.css
+++ b/save-points/03-show-order-status/BlazingPizza.Client/wwwroot/css/site.css
@@ -298,6 +298,7 @@ form {
     top: 0;
     right: 0;
     content: 'X';
+    cursor: pointer;
     color: #fff2cc;
     width: 2rem;
     height: 2rem;

--- a/save-points/04-refactor-state-management/BlazingPizza.Client/wwwroot/css/site.css
+++ b/save-points/04-refactor-state-management/BlazingPizza.Client/wwwroot/css/site.css
@@ -298,6 +298,7 @@ form {
     top: 0;
     right: 0;
     content: 'X';
+    cursor: pointer;
     color: #fff2cc;
     width: 2rem;
     height: 2rem;

--- a/save-points/05-add-authentication/BlazingPizza.Client/wwwroot/css/site.css
+++ b/save-points/05-add-authentication/BlazingPizza.Client/wwwroot/css/site.css
@@ -298,6 +298,7 @@ form {
     top: 0;
     right: 0;
     content: 'X';
+    cursor: pointer;
     color: #fff2cc;
     width: 2rem;
     height: 2rem;

--- a/save-points/06-javascript-interop/BlazingPizza.Client/wwwroot/css/site.css
+++ b/save-points/06-javascript-interop/BlazingPizza.Client/wwwroot/css/site.css
@@ -298,6 +298,7 @@ form {
     top: 0;
     right: 0;
     content: 'X';
+    cursor: pointer;
     color: #fff2cc;
     width: 2rem;
     height: 2rem;

--- a/save-points/07-templated-components/BlazingPizza.Client/wwwroot/css/site.css
+++ b/save-points/07-templated-components/BlazingPizza.Client/wwwroot/css/site.css
@@ -298,6 +298,7 @@ form {
     top: 0;
     right: 0;
     content: 'X';
+    cursor: pointer;
     color: #fff2cc;
     width: 2rem;
     height: 2rem;

--- a/src/BlazingPizza.Client/wwwroot/css/site.css
+++ b/src/BlazingPizza.Client/wwwroot/css/site.css
@@ -298,6 +298,7 @@ form {
     top: 0;
     right: 0;
     content: 'X';
+    cursor: pointer;
     color: #fff2cc;
     width: 2rem;
     height: 2rem;


### PR DESCRIPTION
I changed the cursor for css class `delete-item` to be consistent with other buttons and divs that can be clicked on.

Currently it shows a text cursor because there is text (`x`) as content.

![image](https://user-images.githubusercontent.com/9657173/59220367-1776f180-8bc5-11e9-8562-1ae7c1240441.png)

Hopefully I have every location where it is used.
