### PR TITLE
Rename blazingpizza.componentslibrary to case sensitive

### DIFF
--- a/save-points/00-Starting-point/BlazingPizza.Client/wwwroot/index.html
+++ b/save-points/00-Starting-point/BlazingPizza.Client/wwwroot/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="data:;base64,=" />
     <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
     <link href="css/site.css" rel="stylesheet" />
-    <link href="_content/blazingpizzacomponentslibrary/leaflet/leaflet.css" rel="stylesheet" />
+    <link href="_content/BlazingPizza.ComponentsLibrary/leaflet/leaflet.css" rel="stylesheet" />
     <title>Blazing Pizza</title>
 </head>
 <body>
@@ -16,8 +16,8 @@
     </app>
 
     <script src="_framework/blazor.webassembly.js"></script>
-    <script src="_content/blazingpizzacomponentslibrary/localStorage.js"></script>
-    <script src="_content/blazingpizzacomponentslibrary/deliveryMap.js"></script>
-    <script src="_content/blazingpizzacomponentslibrary/leaflet/leaflet.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/localStorage.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/deliveryMap.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/leaflet/leaflet.js"></script>
 </body>
 </html>

--- a/save-points/01-Components-and-layout/BlazingPizza.Client/wwwroot/index.html
+++ b/save-points/01-Components-and-layout/BlazingPizza.Client/wwwroot/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="data:;base64,=" />
     <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
     <link href="css/site.css" rel="stylesheet" />
-    <link href="_content/blazingpizza.componentslibrary/leaflet/leaflet.css" rel="stylesheet" />
+    <link href="_content/BlazingPizza.ComponentsLibrary/leaflet/leaflet.css" rel="stylesheet" />
     <title>Blazing Pizza</title>
 </head>
 <body>
@@ -16,8 +16,8 @@
     </app>
 
     <script src="_framework/blazor.webassembly.js"></script>
-    <script src="_content/blazingpizza.componentslibrary/localStorage.js"></script>
-    <script src="_content/blazingpizza.componentslibrary/deliveryMap.js"></script>
-    <script src="_content/blazingpizza.componentslibrary/leaflet/leaflet.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/localStorage.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/deliveryMap.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/leaflet/leaflet.js"></script>
 </body>
 </html>

--- a/save-points/02-customize-a-pizza/BlazingPizza.Client/wwwroot/index.html
+++ b/save-points/02-customize-a-pizza/BlazingPizza.Client/wwwroot/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="data:;base64,=" />
     <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
     <link href="css/site.css" rel="stylesheet" />
-    <link href="_content/blazingpizza.componentslibrary/leaflet/leaflet.css" rel="stylesheet" />
+    <link href="_content/BlazingPizza.ComponentsLibrary/leaflet/leaflet.css" rel="stylesheet" />
     <title>Blazing Pizza</title>
 </head>
 <body>
@@ -16,8 +16,8 @@
     </app>
 
     <script src="_framework/blazor.webassembly.js"></script>
-    <script src="_content/blazingpizza.componentslibrary/localStorage.js"></script>
-    <script src="_content/blazingpizza.componentslibrary/deliveryMap.js"></script>
-    <script src="_content/blazingpizza.componentslibrary/leaflet/leaflet.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/localStorage.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/deliveryMap.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/leaflet/leaflet.js"></script>
 </body>
 </html>

--- a/save-points/03-show-order-status/BlazingPizza.Client/wwwroot/index.html
+++ b/save-points/03-show-order-status/BlazingPizza.Client/wwwroot/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="data:;base64,=" />
     <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
     <link href="css/site.css" rel="stylesheet" />
-    <link href="_content/blazingpizza.componentslibrary/leaflet/leaflet.css" rel="stylesheet" />
+    <link href="_content/BlazingPizza.ComponentsLibrary/leaflet/leaflet.css" rel="stylesheet" />
     <title>Blazing Pizza</title>
 </head>
 <body>
@@ -16,8 +16,8 @@
     </app>
 
     <script src="_framework/blazor.webassembly.js"></script>
-    <script src="_content/blazingpizza.componentslibrary/localStorage.js"></script>
-    <script src="_content/blazingpizza.componentslibrary/deliveryMap.js"></script>
-    <script src="_content/blazingpizza.componentslibrary/leaflet/leaflet.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/localStorage.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/deliveryMap.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/leaflet/leaflet.js"></script>
 </body>
 </html>

--- a/save-points/04-refactor-state-management/BlazingPizza.Client/wwwroot/index.html
+++ b/save-points/04-refactor-state-management/BlazingPizza.Client/wwwroot/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="data:;base64,=" />
     <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
     <link href="css/site.css" rel="stylesheet" />
-    <link href="_content/blazingpizza.componentslibrary/leaflet/leaflet.css" rel="stylesheet" />
+    <link href="_content/BlazingPizza.ComponentsLibrary/leaflet/leaflet.css" rel="stylesheet" />
     <title>Blazing Pizza</title>
 </head>
 <body>
@@ -16,8 +16,8 @@
     </app>
 
     <script src="_framework/blazor.webassembly.js"></script>
-    <script src="_content/blazingpizza.componentslibrary/localStorage.js"></script>
-    <script src="_content/blazingpizza.componentslibrary/deliveryMap.js"></script>
-    <script src="_content/blazingpizza.componentslibrary/leaflet/leaflet.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/localStorage.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/deliveryMap.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/leaflet/leaflet.js"></script>
 </body>
 </html>

--- a/save-points/05-checkout-with-validation/BlazingPizza.Client/wwwroot/index.html
+++ b/save-points/05-checkout-with-validation/BlazingPizza.Client/wwwroot/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="data:;base64,=" />
     <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
     <link href="css/site.css" rel="stylesheet" />
-    <link href="_content/blazingpizza.componentslibrary/leaflet/leaflet.css" rel="stylesheet" />
+    <link href="_content/BlazingPizza.ComponentsLibrary/leaflet/leaflet.css" rel="stylesheet" />
     <title>Blazing Pizza</title>
 </head>
 <body>
@@ -16,8 +16,8 @@
     </app>
 
     <script src="_framework/blazor.webassembly.js"></script>
-    <script src="_content/blazingpizza.componentslibrary/localStorage.js"></script>
-    <script src="_content/blazingpizza.componentslibrary/deliveryMap.js"></script>
-    <script src="_content/blazingpizza.componentslibrary/leaflet/leaflet.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/localStorage.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/deliveryMap.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/leaflet/leaflet.js"></script>
 </body>
 </html>

--- a/save-points/06-add-authentication/BlazingPizza.Client/wwwroot/index.html
+++ b/save-points/06-add-authentication/BlazingPizza.Client/wwwroot/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="data:;base64,=" />
     <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
     <link href="css/site.css" rel="stylesheet" />
-    <link href="_content/blazingpizza.componentslibrary/leaflet/leaflet.css" rel="stylesheet" />
+    <link href="_content/BlazingPizza.ComponentsLibrary/leaflet/leaflet.css" rel="stylesheet" />
     <title>Blazing Pizza</title>
 </head>
 <body>
@@ -16,8 +16,8 @@
     </app>
 
     <script src="_framework/blazor.webassembly.js"></script>
-    <script src="_content/blazingpizza.componentslibrary/localStorage.js"></script>
-    <script src="_content/blazingpizza.componentslibrary/deliveryMap.js"></script>
-    <script src="_content/blazingpizza.componentslibrary/leaflet/leaflet.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/localStorage.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/deliveryMap.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/leaflet/leaflet.js"></script>
 </body>
 </html>

--- a/save-points/07-javascript-interop/BlazingPizza.Client/wwwroot/index.html
+++ b/save-points/07-javascript-interop/BlazingPizza.Client/wwwroot/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="data:;base64,=" />
     <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
     <link href="css/site.css" rel="stylesheet" />
-    <link href="_content/blazingpizza.componentslibrary/leaflet/leaflet.css" rel="stylesheet" />
+    <link href="_content/BlazingPizza.ComponentsLibrary/leaflet/leaflet.css" rel="stylesheet" />
     <title>Blazing Pizza</title>
 </head>
 <body>
@@ -16,8 +16,8 @@
     </app>
 
     <script src="_framework/blazor.webassembly.js"></script>
-    <script src="_content/blazingpizza.componentslibrary/localStorage.js"></script>
-    <script src="_content/blazingpizza.componentslibrary/deliveryMap.js"></script>
-    <script src="_content/blazingpizza.componentslibrary/leaflet/leaflet.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/localStorage.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/deliveryMap.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/leaflet/leaflet.js"></script>
 </body>
 </html>

--- a/save-points/08-templated-components/BlazingPizza.Client/wwwroot/index.html
+++ b/save-points/08-templated-components/BlazingPizza.Client/wwwroot/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="data:;base64,=" />
     <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
     <link href="css/site.css" rel="stylesheet" />
-    <link href="_content/blazingpizza.componentslibrary/leaflet/leaflet.css" rel="stylesheet" />
+    <link href="_content/BlazingPizza.ComponentsLibrary/leaflet/leaflet.css" rel="stylesheet" />
     <title>Blazing Pizza</title>
 </head>
 <body>
@@ -16,8 +16,8 @@
     </app>
 
     <script src="_framework/blazor.webassembly.js"></script>
-    <script src="_content/blazingpizza.componentslibrary/localStorage.js"></script>
-    <script src="_content/blazingpizza.componentslibrary/deliveryMap.js"></script>
-    <script src="_content/blazingpizza.componentslibrary/leaflet/leaflet.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/localStorage.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/deliveryMap.js"></script>
+    <script src="_content/BlazingPizza.ComponentsLibrary/leaflet/leaflet.js"></script>
 </body>
 </html>


### PR DESCRIPTION
When using case insensitive name, the javascript file from BlazingPizza.ComponentsLibrary can't be loaded. Related issue https://github.com/dotnet-presentations/blazor-workshop/issues/136