### PR TITLE
Fix for @bind-value:event doesn't compile

### DIFF
--- a/docs/02-customize-a-pizza.md
+++ b/docs/02-customize-a-pizza.md
@@ -159,7 +159,7 @@ But if we use `@bind` with no further changes, the behavior isn't exactly what w
 We'd prefer to see updates as the slider is moved. Data binding in Blazor allows for this by letting you specify what event triggers a change using the syntax `@bind:<eventname>`. So, to bind using the `oninput` event instead do this:
 
 ```html
-<input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="@Pizza.Size" @bind:event="oninput" />
+<input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind="@Pizza.Size" @bind:event="oninput" />
 ```
 
 The pizza size should now update as you move the slider.

--- a/docs/02-customize-a-pizza.md
+++ b/docs/02-customize-a-pizza.md
@@ -159,7 +159,7 @@ But if we use `@bind` with no further changes, the behavior isn't exactly what w
 We'd prefer to see updates as the slider is moved. Data binding in Blazor allows for this by letting you specify what event triggers a change using the syntax `@bind:<eventname>`. So, to bind using the `oninput` event instead do this:
 
 ```html
-<input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="@Pizza.Size" @bind-value:event="oninput" />
+<input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="@Pizza.Size" @bind:event="oninput" />
 ```
 
 The pizza size should now update as you move the slider.

--- a/notes/outline.md
+++ b/notes/outline.md
@@ -25,7 +25,7 @@ Lunch
     - Index needs to handle the hide/show of the dialog 
     - Index needs to pass in the Pizza object as well as two 'command' delegates
     - Using `@bind` and `@onclick` on the customize dialog to update prices in real time
-    - explain the use of `@bind-value:event="oninput"` on the slider
+    - explain the use of `@bind:event="oninput"` on the slider
     - cancel button should close the dialog
     - confirm button should close the dialog and add to order
     - now add the markup for sidebar which will display orders

--- a/save-points/02-customize-a-pizza/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
+++ b/save-points/02-customize-a-pizza/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
@@ -9,7 +9,7 @@
         <form class="dialog-body">
             <div>
                 <label>Size:</label>
-                <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="Pizza.Size" @bind:event="oninput" />
+                <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind="Pizza.Size" @bind:event="oninput" />
                 <span class="size-label">
                     @(Pizza.Size)" (£@(Pizza.GetFormattedTotalPrice()))
                 </span>

--- a/save-points/02-customize-a-pizza/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
+++ b/save-points/02-customize-a-pizza/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
@@ -9,7 +9,7 @@
         <form class="dialog-body">
             <div>
                 <label>Size:</label>
-                <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="Pizza.Size" @bind-value:event="oninput" />
+                <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="Pizza.Size" @bind:event="oninput" />
                 <span class="size-label">
                     @(Pizza.Size)" (£@(Pizza.GetFormattedTotalPrice()))
                 </span>

--- a/save-points/03-show-order-status/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
+++ b/save-points/03-show-order-status/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
@@ -9,7 +9,7 @@
         <form class="dialog-body">
             <div>
                 <label>Size:</label>
-                <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="Pizza.Size" @bind:event="oninput" />
+                <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind="Pizza.Size" @bind:event="oninput" />
                 <span class="size-label">
                     @(Pizza.Size)" (£@(Pizza.GetFormattedTotalPrice()))
                 </span>

--- a/save-points/03-show-order-status/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
+++ b/save-points/03-show-order-status/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
@@ -9,7 +9,7 @@
         <form class="dialog-body">
             <div>
                 <label>Size:</label>
-                <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="Pizza.Size" @bind-value:event="oninput" />
+                <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="Pizza.Size" @bind:event="oninput" />
                 <span class="size-label">
                     @(Pizza.Size)" (£@(Pizza.GetFormattedTotalPrice()))
                 </span>

--- a/save-points/04-refactor-state-management/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
+++ b/save-points/04-refactor-state-management/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
@@ -9,7 +9,7 @@
         <form class="dialog-body">
             <div>
                 <label>Size:</label>
-                <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="Pizza.Size" @bind:event="oninput" />
+                <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind="Pizza.Size" @bind:event="oninput" />
                 <span class="size-label">
                     @(Pizza.Size)" (£@(Pizza.GetFormattedTotalPrice()))
                 </span>

--- a/save-points/04-refactor-state-management/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
+++ b/save-points/04-refactor-state-management/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
@@ -9,7 +9,7 @@
         <form class="dialog-body">
             <div>
                 <label>Size:</label>
-                <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="Pizza.Size" @bind-value:event="oninput" />
+                <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="Pizza.Size" @bind:event="oninput" />
                 <span class="size-label">
                     @(Pizza.Size)" (£@(Pizza.GetFormattedTotalPrice()))
                 </span>

--- a/save-points/05-checkout-with-validation/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
+++ b/save-points/05-checkout-with-validation/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
@@ -9,7 +9,7 @@
         <form class="dialog-body">
             <div>
                 <label>Size:</label>
-                <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="Pizza.Size" @bind:event="oninput" />
+                <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind="Pizza.Size" @bind:event="oninput" />
                 <span class="size-label">
                     @(Pizza.Size)" (£@(Pizza.GetFormattedTotalPrice()))
                 </span>

--- a/save-points/05-checkout-with-validation/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
+++ b/save-points/05-checkout-with-validation/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
@@ -9,7 +9,7 @@
         <form class="dialog-body">
             <div>
                 <label>Size:</label>
-                <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="Pizza.Size" @bind-value:event="oninput" />
+                <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="Pizza.Size" @bind:event="oninput" />
                 <span class="size-label">
                     @(Pizza.Size)" (£@(Pizza.GetFormattedTotalPrice()))
                 </span>

--- a/save-points/06-add-authentication/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
+++ b/save-points/06-add-authentication/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
@@ -9,7 +9,7 @@
         <form class="dialog-body">
             <div>
                 <label>Size:</label>
-                <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="Pizza.Size" @bind:event="oninput" />
+                <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind="Pizza.Size" @bind:event="oninput" />
                 <span class="size-label">
                     @(Pizza.Size)" (£@(Pizza.GetFormattedTotalPrice()))
                 </span>

--- a/save-points/06-add-authentication/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
+++ b/save-points/06-add-authentication/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
@@ -9,7 +9,7 @@
         <form class="dialog-body">
             <div>
                 <label>Size:</label>
-                <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="Pizza.Size" @bind-value:event="oninput" />
+                <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="Pizza.Size" @bind:event="oninput" />
                 <span class="size-label">
                     @(Pizza.Size)" (£@(Pizza.GetFormattedTotalPrice()))
                 </span>

--- a/save-points/07-javascript-interop/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
+++ b/save-points/07-javascript-interop/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
@@ -9,7 +9,7 @@
         <form class="dialog-body">
             <div>
                 <label>Size:</label>
-                <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="Pizza.Size" @bind:event="oninput" />
+                <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind="Pizza.Size" @bind:event="oninput" />
                 <span class="size-label">
                     @(Pizza.Size)" (£@(Pizza.GetFormattedTotalPrice()))
                 </span>

--- a/save-points/07-javascript-interop/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
+++ b/save-points/07-javascript-interop/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
@@ -9,7 +9,7 @@
         <form class="dialog-body">
             <div>
                 <label>Size:</label>
-                <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="Pizza.Size" @bind-value:event="oninput" />
+                <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="Pizza.Size" @bind:event="oninput" />
                 <span class="size-label">
                     @(Pizza.Size)" (£@(Pizza.GetFormattedTotalPrice()))
                 </span>

--- a/save-points/08-templated-components/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
+++ b/save-points/08-templated-components/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
@@ -7,7 +7,7 @@
 <form class="dialog-body">
     <div>
         <label>Size:</label>
-        <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="Pizza.Size" @bind-value:event="oninput" />
+        <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="Pizza.Size" @bind:event="oninput" />
         <span class="size-label">
             @(Pizza.Size)" (£@(Pizza.GetFormattedTotalPrice()))
         </span>

--- a/save-points/08-templated-components/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
+++ b/save-points/08-templated-components/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
@@ -7,7 +7,7 @@
 <form class="dialog-body">
     <div>
         <label>Size:</label>
-        <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="Pizza.Size" @bind:event="oninput" />
+        <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind="Pizza.Size" @bind:event="oninput" />
         <span class="size-label">
             @(Pizza.Size)" (£@(Pizza.GetFormattedTotalPrice()))
         </span>

--- a/src/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
+++ b/src/BlazingPizza.Client/Shared/ConfigurePizzaDialog.razor
@@ -7,7 +7,7 @@
 <form class="dialog-body">
     <div>
         <label>Size:</label>
-        <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="Pizza.Size" @bind-value:event="oninput" />
+        <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" @bind-value="Pizza.Size" @bind:event="oninput" />
         <span class="size-label">
             @(Pizza.Size)" (£@(Pizza.GetFormattedTotalPrice()))
         </span>


### PR DESCRIPTION
When updating the slider based off oninput event  - looks like there was a syntax change and the @bind-value:event doesn't compile anymore.