### PR TITLE
Update 09-progressive-web-app.md

### DIFF
--- a/docs/09-progressive-web-app.md
+++ b/docs/09-progressive-web-app.md
@@ -164,7 +164,7 @@ private static async Task SendNotificationAsync(Order order, NotificationSubscri
     var webPushClient = new WebPushClient();
     try
     {
-        var payload = JsonSerializer.Serialize(new
+        var payload = JsonConvert.SerializeObject(new
         {
             message,
             url = $"myorders/{order.OrderId}",


### PR DESCRIPTION
`JsonSerializer.Serialize` needs a `JsonWriter` or `TextWriter` as first instance in `Newtonsoft.Json` 12.0.2 which is referenced by `WebPush`.