### PR TITLE
Update docs and typo

### DIFF
--- a/docs/01-components-and-layout.md
+++ b/docs/01-components-and-layout.md
@@ -60,7 +60,7 @@ Override the `OnInitializedAsync` method in the `@code` block to retrieve the li
 @code {
     List<PizzaSpecial> specials;
 
-    protected async override Task OnInitializedAsync()
+    protected override async Task OnInitializedAsync()
     {
         specials = await HttpClient.GetJsonAsync<List<PizzaSpecial>>("specials");
     }

--- a/docs/03-show-order-status.md
+++ b/docs/03-show-order-status.md
@@ -17,7 +17,7 @@ Open `Shared/MainLayout.razor`. As an experiment, let's try adding a new link el
 </div>
 ```
 
-> Notice how the URL we're linking to does *not* start with a `/`. If you linked to `/myorders`, it would appear to work the same, but if you ever wanted to deploy the app to a non-root URL the the link would break. The `<base href="/">` tag in `index.html` specifies the prefix for all non-slash-prefixed URLs in the app, regardless of which component renders them.
+> Notice how the URL we're linking to does *not* start with a `/`. If you linked to `/myorders`, it would appear to work the same, but if you ever wanted to deploy the app to a non-root URL the link would break. The `<base href="/">` tag in `index.html` specifies the prefix for all non-slash-prefixed URLs in the app, regardless of which component renders them.
 
 If you run the app now, you'll see the link, styled as expected:
 

--- a/docs/05-checkout-with-validation.md
+++ b/docs/05-checkout-with-validation.md
@@ -41,10 +41,22 @@ As usual, you'll need to `@inject` values for `OrderState`, `HttpClient`, and `N
 Next, let's bring customers here when they try to submit orders. Back in `Index.razor`, make sure you've deleted the `PlaceOrder` method, and then change the order submission button into a regular HTML link to the `/checkout` URL, i.e.:
 
 ```html
-<a href="checkout" class="btn btn-warning" disabled="@(OrderState.Order.Pizzas.Count == 0)">
+<a href="checkout" class="@CheckoutBtnCssClass">
     Order >
 </a>
 ```
+
+Please note, we removed the `disabled` attribute, since HTML links do not support it. Instead, we are going to control the behavior through the `CheckoutBtnCssClass` property. To complete this change add the property to the `@code` block:
+
+```cs
+@code{
+    List<PizzaSpecial> specials;
+
+    string CheckoutBtnCssClass => OrderState.Order.Pizzas.Count == 0 ? "btn btn-warning disabled" : "btn btn-warning";
+
+    \\ Leave existing code here
+}
+``` 
 
 Now, when you run the app, you should be able to reach the checkout page by clicking the *Order* button, and from there can click *Place order* to confirm it.
 

--- a/docs/07-javascript-interop.md
+++ b/docs/07-javascript-interop.md
@@ -48,7 +48,6 @@ Add an `@using` for this namespace to the root `_Imports.razor` to bring this co
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.AspNetCore.Components.Forms
-@using Microsoft.AspNetCore.Components.Layouts
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.JSInterop
 @using BlazingPizza.Client

--- a/save-points/01-Components-and-layout/BlazingPizza.Client/Pages/Index.razor
+++ b/save-points/01-Components-and-layout/BlazingPizza.Client/Pages/Index.razor
@@ -22,7 +22,7 @@
 @code {
     List<PizzaSpecial> specials;
 
-    protected async override Task OnInitializedAsync()
+    protected override async Task OnInitializedAsync()
     {
         specials = await HttpClient.GetJsonAsync<List<PizzaSpecial>>("specials");
     }

--- a/save-points/02-customize-a-pizza/BlazingPizza.Client/Pages/Index.razor
+++ b/save-points/02-customize-a-pizza/BlazingPizza.Client/Pages/Index.razor
@@ -59,7 +59,7 @@
     bool showingConfigureDialog;
     Order order = new Order();
 
-    protected async override Task OnInitializedAsync()
+    protected override async Task OnInitializedAsync()
     {
         specials = await HttpClient.GetJsonAsync<List<PizzaSpecial>>("specials");
     }

--- a/save-points/03-show-order-status/BlazingPizza.Client/Pages/Index.razor
+++ b/save-points/03-show-order-status/BlazingPizza.Client/Pages/Index.razor
@@ -60,7 +60,7 @@
     bool showingConfigureDialog;
     Order order = new Order();
 
-    protected async override Task OnInitializedAsync()
+    protected override async Task OnInitializedAsync()
     {
         specials = await HttpClient.GetJsonAsync<List<PizzaSpecial>>("specials");
     }

--- a/save-points/04-refactor-state-management/BlazingPizza.Client/Pages/Index.razor
+++ b/save-points/04-refactor-state-management/BlazingPizza.Client/Pages/Index.razor
@@ -59,7 +59,7 @@
     List<PizzaSpecial> specials;
     Order Order => OrderState.Order;
 
-    protected async override Task OnInitializedAsync()
+    protected override async Task OnInitializedAsync()
     {
         specials = await HttpClient.GetJsonAsync<List<PizzaSpecial>>("specials");
     }

--- a/save-points/05-checkout-with-validation/BlazingPizza.Client/Pages/Index.razor
+++ b/save-points/05-checkout-with-validation/BlazingPizza.Client/Pages/Index.razor
@@ -41,7 +41,7 @@
     <div class="order-total @(Order.Pizzas.Any() ? "" : "hidden")">
         Total:
         <span class="total-price">@Order.GetFormattedTotalPrice()</span>
-        <a href="checkout" class="btn btn-warning" disabled="@(Order.Pizzas.Count == 0)">
+        <a href="checkout" class="@CheckoutBtnCssClass">
             Order >
         </a>
     </div>
@@ -57,9 +57,10 @@
 
 @code {
     List<PizzaSpecial> specials;
+    string CheckoutBtnCssClass => OrderState.Order.Pizzas.Count == 0 ? "btn btn-warning disabled" : "btn btn-warning";
     Order Order => OrderState.Order;
 
-    protected async override Task OnInitializedAsync()
+    protected override async Task OnInitializedAsync()
     {
         specials = await HttpClient.GetJsonAsync<List<PizzaSpecial>>("specials");
     }

--- a/save-points/06-add-authentication/BlazingPizza.Client/Pages/Index.razor
+++ b/save-points/06-add-authentication/BlazingPizza.Client/Pages/Index.razor
@@ -41,7 +41,7 @@
     <div class="order-total @(Order.Pizzas.Any() ? "" : "hidden")">
         Total:
         <span class="total-price">@Order.GetFormattedTotalPrice()</span>
-        <a href="checkout" class="btn btn-warning" disabled="@(Order.Pizzas.Count == 0)">
+        <a href="checkout" class="@CheckoutBtnCssClass">
             Order >
         </a>
     </div>
@@ -57,9 +57,10 @@
 
 @code {
     List<PizzaSpecial> specials;
+    string CheckoutBtnCssClass => OrderState.Order.Pizzas.Count == 0 ? "btn btn-warning disabled" : "btn btn-warning";
     Order Order => OrderState.Order;
 
-    protected async override Task OnInitializedAsync()
+    protected override async Task OnInitializedAsync()
     {
         specials = await HttpClient.GetJsonAsync<List<PizzaSpecial>>("specials");
     }

--- a/save-points/07-javascript-interop/BlazingPizza.Client/Pages/Index.razor
+++ b/save-points/07-javascript-interop/BlazingPizza.Client/Pages/Index.razor
@@ -42,7 +42,7 @@
     <div class="order-total @(Order.Pizzas.Any() ? "" : "hidden")">
         Total:
         <span class="total-price">@Order.GetFormattedTotalPrice()</span>
-        <a href="checkout" class="btn btn-warning" disabled="@(Order.Pizzas.Count == 0)">
+        <a href="checkout" class="@CheckoutBtnCssClass">
             Order >
         </a>
     </div>
@@ -58,9 +58,10 @@
 
 @code {
     List<PizzaSpecial> specials;
+    string CheckoutBtnCssClass => OrderState.Order.Pizzas.Count == 0 ? "btn btn-warning disabled" : "btn btn-warning";
     Order Order => OrderState.Order;
 
-    protected async override Task OnInitializedAsync()
+    protected override async Task OnInitializedAsync()
     {
         specials = await HttpClient.GetJsonAsync<List<PizzaSpecial>>("specials");
     }

--- a/save-points/08-templated-components/BlazingPizza.Client/Pages/Index.razor
+++ b/save-points/08-templated-components/BlazingPizza.Client/Pages/Index.razor
@@ -42,7 +42,7 @@
     <div class="order-total @(Order.Pizzas.Any() ? "" : "hidden")">
         Total:
         <span class="total-price">@Order.GetFormattedTotalPrice()</span>
-        <a href="checkout" class="btn btn-warning" disabled="@(Order.Pizzas.Count == 0)">
+        <a href="checkout" class="@CheckoutBtnCssClass">
             Order >
         </a>
     </div>
@@ -57,9 +57,10 @@
 
 @code {
     List<PizzaSpecial> specials;
+    string CheckoutBtnCssClass => OrderState.Order.Pizzas.Count == 0 ? "btn btn-warning disabled" : "btn btn-warning";
     Order Order => OrderState.Order;
 
-    protected async override Task OnInitializedAsync()
+    protected override async Task OnInitializedAsync()
     {
         specials = await HttpClient.GetJsonAsync<List<PizzaSpecial>>("specials");
     }

--- a/save-points/09-progressive-web-app/BlazingPizza.Client/Pages/Index.razor
+++ b/save-points/09-progressive-web-app/BlazingPizza.Client/Pages/Index.razor
@@ -42,7 +42,7 @@
     <div class="order-total @(Order.Pizzas.Any() ? "" : "hidden")">
         Total:
         <span class="total-price">@Order.GetFormattedTotalPrice()</span>
-        <a href="checkout" class="btn btn-warning" disabled="@(Order.Pizzas.Count == 0)">
+        <a href="checkout" class="@CheckoutBtnCssClass">
             Order >
         </a>
     </div>
@@ -57,9 +57,10 @@
 
 @code {
     List<PizzaSpecial> specials;
+    string CheckoutBtnCssClass => OrderState.Order.Pizzas.Count == 0 ? "btn btn-warning disabled" : "btn btn-warning";
     Order Order => OrderState.Order;
 
-    protected async override Task OnInitializedAsync()
+    protected override async Task OnInitializedAsync()
     {
         specials = await HttpClient.GetJsonAsync<List<PizzaSpecial>>("specials");
     }

--- a/src/BlazingPizza.Client/Pages/Index.razor
+++ b/src/BlazingPizza.Client/Pages/Index.razor
@@ -59,7 +59,7 @@
     List<PizzaSpecial> specials;
     Order Order => OrderState.Order;
 
-    protected async override Task OnInitializedAsync()
+    protected override async Task OnInitializedAsync()
     {
         specials = await HttpClient.GetJsonAsync<List<PizzaSpecial>>("specials");
     }


### PR DESCRIPTION
- Having "protected async override" will cause green squiggles to show up in Visual Studio, with the message "Inconsistent modifiers declaration order".
- Having this `@using Microsoft.AspNetCore.Components.Layouts` will result in a compilation error as it doesn't exist.
- Anchor tags do not support disabled attribute.