### PR TITLE
cancel unnecessary polling

### DIFF
--- a/src/BlazingPizza.Client/Pages/OrderDetails.razor
+++ b/src/BlazingPizza.Client/Pages/OrderDetails.razor
@@ -77,6 +77,11 @@
 
             StateHasChanged();
 
+            if (orderWithStatus.StatusText == "Delivered")
+            {
+                pollingCancellationToken.Cancel();               
+            }
+
             await Task.Delay(4000);
         }
     }


### PR DESCRIPTION
After order is delivered, no need to keep calling api to get status.