### PR TITLE
Fixed  type parameter in call to AddRemoteAuthentication()

### DIFF
--- a/docs/06-authentication-and-authorization.md
+++ b/docs/06-authentication-and-authorization.md
@@ -516,7 +516,7 @@ To configure the authentication system to use our `PizzaAuthenticationState` ins
 
 ```csharp
 // Add auth services
-builder.Services.AddRemoteAuthentication<RemoteAuthenticationState, ApiAuthorizationProviderOptions>();
+builder.Services.AddRemoteAuthentication<PizzaAuthenticationState, ApiAuthorizationProviderOptions>();
 builder.Services.AddApiAuthorization();
 ```
 


### PR DESCRIPTION
Fixed the type parameter in the first call to AddRemoteAuthentication() - was RemoteAuthenticationState, should be PizzaAuthenticationState