### PR TITLE
IDisposable dependencies should not be Transient

### DIFF
--- a/src/BlazingPizza.Client/Program.cs
+++ b/src/BlazingPizza.Client/Program.cs
@@ -13,7 +13,7 @@ namespace BlazingPizza.Client
             var builder = WebAssemblyHostBuilder.CreateDefault(args);
             builder.RootComponents.Add<App>("app");
 
-            builder.Services.AddTransient(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+            builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
             builder.Services.AddScoped<OrderState>();
 
             // Add auth services


### PR DESCRIPTION
Transient dependencies are created every time they are requested, but if they implement IDisposable then the DI container holds onto a reference until it is disposed. This means we leak HttpClient instances.

See "Avoiding memory leaks"
https://blazor-university.com/dependency-injection/dependency-lifetimes-and-scopes/transient-dependencies