### PR TITLE
Update 01-components-and-layout.md to match source in 01 checkpoint

### DIFF
--- a/docs/01-components-and-layout.md
+++ b/docs/01-components-and-layout.md
@@ -123,7 +123,9 @@ Update the `MainLayout` component to define a top bar with a branding logo and a
 @inherits LayoutComponentBase
 
 <div class="top-bar">
-    <img class="logo" src="img/logo.svg" />
+    <a class="logo" href="">
+        <img src="img/logo.svg" />
+    </a>
 
     <NavLink href="" class="nav-tab" Match="NavLinkMatch.All">
         <img src="img/pizza-slice.svg" />


### PR DESCRIPTION
The src has <a> around <img> that is missing from the doc.
Spotted by Mr csharpfritz in his stream.