### PR TITLE
Copy across polling cancel on delivered status

### DIFF
--- a/docs/06-authentication-and-authorization.md
+++ b/docs/06-authentication-and-authorization.md
@@ -314,7 +314,15 @@ private async void PollForUpdates()
         {
             orderWithStatus = await OrdersClient.GetOrder(OrderId);
             StateHasChanged();
-            await Task.Delay(4000);
+
+            if (orderWithStatus.IsDelivered)
+            {
+                pollingCancellationToken.Cancel();
+            }
+            else
+            {
+                await Task.Delay(4000);
+            }
         }
         catch (AccessTokenNotAvailableException ex)
         {


### PR DESCRIPTION
I suspect when this change was made on step 3, the same change was missed here.