### PR TITLE
Outcommented the required attributes above certain fields in Address.cs

### DIFF
--- a/save-points/00-get-started/BlazingPizza.Shared/Address.cs
+++ b/save-points/00-get-started/BlazingPizza.Shared/Address.cs
@@ -4,21 +4,21 @@ public class Address
 {
     public int Id { get; set; }
 
-    [Required, MaxLength(100)]
+    // [Required, MaxLength(100)]
     public string Name { get; set; }
 
-    [Required, MaxLength(100)]
+    // [Required, MaxLength(100)]
     public string Line1 { get; set; }
 
     [MaxLength(100)]
     public string Line2 { get; set; }
 
-    [Required, MaxLength(50)]
+    // [Required, MaxLength(50)]
     public string City { get; set; }
 
-    [Required, MaxLength(20)]
+    // [Required, MaxLength(20)]
     public string Region { get; set; }
 
-    [Required, MaxLength(20)]
+    // [Required, MaxLength(20)]
     public string PostalCode { get; set; }
 }

--- a/save-points/01-Components-and-layout/BlazingPizza.Shared/Address.cs
+++ b/save-points/01-Components-and-layout/BlazingPizza.Shared/Address.cs
@@ -4,21 +4,21 @@ public class Address
 {
     public int Id { get; set; }
 
-    [Required, MaxLength(100)]
+    // [Required, MaxLength(100)]
     public string Name { get; set; }
 
-    [Required, MaxLength(100)]
+    // [Required, MaxLength(100)]
     public string Line1 { get; set; }
 
     [MaxLength(100)]
     public string Line2 { get; set; }
 
-    [Required, MaxLength(50)]
+    // [Required, MaxLength(50)]
     public string City { get; set; }
 
-    [Required, MaxLength(20)]
+    // [Required, MaxLength(20)]
     public string Region { get; set; }
 
-    [Required, MaxLength(20)]
+    // [Required, MaxLength(20)]
     public string PostalCode { get; set; }
 }

--- a/save-points/02-customize-a-pizza/BlazingPizza.Shared/Address.cs
+++ b/save-points/02-customize-a-pizza/BlazingPizza.Shared/Address.cs
@@ -6,21 +6,21 @@ public class Address
 {
     public int Id { get; set; }
 
-    [Required, MaxLength(100)]
+    // [Required, MaxLength(100)]
     public string Name { get; set; }
 
-    [Required, MaxLength(100)]
+    // [Required, MaxLength(100)]
     public string Line1 { get; set; }
 
     [MaxLength(100)]
     public string Line2 { get; set; }
 
-    [Required, MaxLength(50)]
+    // [Required, MaxLength(50)]
     public string City { get; set; }
 
-    [Required, MaxLength(20)]
+    // [Required, MaxLength(20)]
     public string Region { get; set; }
 
-    [Required, MaxLength(20)]
+    // [Required, MaxLength(20)]
     public string PostalCode { get; set; }
 }


### PR DESCRIPTION
This outcomments required attributes above certain fields in Address.cs which otherwise results in an exception being thrown when following the guide from save-point 00, at save-point 02 (when clicking the order pizza button).
See issue #339 