### PR TITLE
The "@" char prefix in Loader="LoadOrders" is not required

### DIFF
--- a/docs/08-templated-components.md
+++ b/docs/08-templated-components.md
@@ -392,7 +392,7 @@ Adding the `Loader` attribute should fix the issue.
 
 ```html
 <div class="main">
-    <TemplatedList Loader="@LoadOrders">
+    <TemplatedList Loader="LoadOrders">
     </TemplatedList>
 </div>
 ```
@@ -416,7 +416,7 @@ For our `TemplatedList` here's an example that sets each parameter to some dummy
 
 ```html
 <div class="main">
-    <TemplatedList Loader="@LoadOrders">
+    <TemplatedList Loader="LoadOrders">
         <Loading>Hi there!</Loading>
         <Empty>
             How are you?
@@ -432,7 +432,7 @@ The `Item` parameter is a `RenderFragment<T>` - which accepts a parameter. By de
 
 ```html
 <div class="main">
-    <TemplatedList Loader="@LoadOrders">
+    <TemplatedList Loader="LoadOrders">
         <Loading>Hi there!</Loading>
         <Empty>
             How are you?
@@ -448,7 +448,7 @@ Now we want to include all of the existing content from `MyOrders.razor`, so put
 
 ```html
 <div class="main">
-    <TemplatedList Loader="@LoadOrders" ListGroupClass="orders-list">
+    <TemplatedList Loader="LoadOrders" ListGroupClass="orders-list">
         <Loading>Loading...</Loading>
         <Empty>
             <h2>No orders placed</h2>


### PR DESCRIPTION
Because the reference to LoadOrders in TemplatedList is automatically recognized, the "@" prefix is not required. Best regards.