### PR TITLE
Push notifications where not showing on Safari

### DIFF
--- a/docs/09-progressive-web-app.md
+++ b/docs/09-progressive-web-app.md
@@ -188,7 +188,7 @@ private static async Task SendNotificationAsync(Order order, NotificationSubscri
     var privateKey = "OrubzSz3yWACscZXjFQrrtDwCKg-TGFuWhluQ2wLXDo";
 
     var pushSubscription = new PushSubscription(subscription.Url, subscription.P256dh, subscription.Auth);
-    var vapidDetails = new VapidDetails("mailto:<someone@example.com>", publicKey, privateKey);
+    var vapidDetails = new VapidDetails("mailto:someone@example.com", publicKey, privateKey);
     var webPushClient = new WebPushClient();
     try
     {

--- a/src/BlazingPizza.Server/OrdersController.cs
+++ b/src/BlazingPizza.Server/OrdersController.cs
@@ -106,7 +106,7 @@ public class OrdersController : Controller
         var privateKey = "OrubzSz3yWACscZXjFQrrtDwCKg-TGFuWhluQ2wLXDo";
 
         var pushSubscription = new PushSubscription(subscription.Url, subscription.P256dh, subscription.Auth);
-        var vapidDetails = new VapidDetails("mailto:<someone@example.com>", publicKey, privateKey);
+        var vapidDetails = new VapidDetails("mailto:someone@example.com", publicKey, privateKey);
         var webPushClient = new WebPushClient();
         try
         {


### PR DESCRIPTION
Push notifications where not showing on Safari because of a restriction from Apple. This has been discussed in this [issue](https://github.com/web-push-libs/webpush-java/issues/201#issuecomment-1443427513).